### PR TITLE
fix: chrome variant detection on macOS and windows

### DIFF
--- a/lib/darwin/index.js
+++ b/lib/darwin/index.js
@@ -9,6 +9,8 @@ function browser(id, versionKey) {
 
 exports.chrome = browser('com.google.Chrome', 'KSVersion');
 exports['chrome-canary'] = browser('com.google.Chrome.canary', 'KSVersion');
+exports['chrome-dev'] = browser('com.google.Chrome.dev', 'KSVersion');
+exports['chrome-beta'] = browser('com.google.Chrome.beta', 'KSVersion');
 exports.chromium = browser('org.chromium.Chromium', 'CFBundleShortVersionString');
 exports.firefox = browser('org.mozilla.firefox', 'CFBundleShortVersionString');
 exports['firefox-developer'] = browser('org.mozilla.firefoxdeveloperedition', 'CFBundleShortVersionString');

--- a/lib/detect.js
+++ b/lib/detect.js
@@ -17,9 +17,13 @@ function detectWindows(callback) {
         var available = found.map(function (browser) {
             var config = browsers.typeConfig(browser.name);
 
+            let configName = browser.name
+            if(browser.channel && browser.channel !== "stable" && browser.channel !== "release")
+                configName = `${browser.name}-${browser.channel}`
+
             return assign({
                 type: browser.name,
-                name: browser.name,
+                name: configName,
                 command: browser.path,
                 version: browser.version
             }, config);

--- a/lib/detect.js
+++ b/lib/detect.js
@@ -14,12 +14,15 @@ function detectWindows(callback) {
     winDetect(function (error, found) {
         if (error) return callback(error);
 
-        var available = found.map(function (browser) {
-            var config = browsers.typeConfig(browser.name);
+        const available = found.map(function (browser) {
+            const config = browsers.typeConfig(browser.name);
 
-            let configName = browser.name
-            if(browser.channel && browser.channel !== "stable" && browser.channel !== "release")
-                configName = `${browser.name}-${browser.channel}`
+            let configName;
+            if (browser.channel && browser.channel !== "stable" && browser.channel !== "release") {
+                configName = `${browser.name}-${browser.channel}`;
+            } else {
+                configName = browser.name;
+            }
 
             return assign({
                 type: browser.name,


### PR DESCRIPTION
# Issue
In case there are various versions of chrome (canary, dev, beta and stable) the results are correct only on linux

### On macOS:
Only detects stable chrome 

### On Windows:
The name and type of all the different versions are the same, hence we need to differentiate the entries based on path name which seems like a hacky solution

# Steps to reproduce the bug
run `node example/detect.js` on different platforms

# Changes / Proposed Fix
1. Check the `chrome-dev` and `chrome-beta` bundleIds on macOS
2. rename the `name` in the resultant config of detected browsers on windows from `browser.name` to `{browser.name}-{browser.channel}`