### PR TITLE
[Add] Support for launching Firefox with default system profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Open given URI in a browser and return an instance of it.
 - *Boolean* `options.detached` - if true, then killing your script will not kill the opened browser
 - *Array|String* `options.noProxy` - An array of strings, containing proxy routes to skip over
 - *Boolean* `options.headless` - run a browser in a headless mode (only if **Xvfb** available)
-- *String|null* `options.profile` - path to a directory to use for the browser profile, overriding the default. Null to force use of the default system profile (Chromium-based browsers only).
+- *String|null* `options.profile` - path to a directory to use for the browser profile, overriding the default. Use `null` to force use of the default system profile (supported for Firefox & Chromium-based browsers only). Note that configuration options like `proxy` & `prefs` can't be used in Firefox with the default system profile.
 - *Function* `callback(err, instance)` - function fired when started a browser `instance` or an error occurred
 
 ### `launch.browsers`

--- a/lib/run.js
+++ b/lib/run.js
@@ -116,82 +116,76 @@ function formatNoProxyChrome(options) {
  * @param  {Function} callback Callback function
  */
 setups.firefox = function (browser, options, callback) {
-    if (options.profile !== null) {
-        var profileDir =
-            options.profile ||
-            path.join(os.tmpdir(), "browser-launcher" + uid(10));
-        var file = path.join(profileDir, "prefs.js");
-        var prefs = options.skipDefaults
-            ? {}
-            : {
-                  "browser.shell.checkDefaultBrowser": false,
-                  "browser.bookmarks.restore_default_bookmarks": false,
-                  "dom.disable_open_during_load": false,
-                  "dom.max_script_run_time": 0,
-                  "browser.cache.disk.capacity": 0,
-                  "browser.cache.disk.smart_size.enabled": false,
-                  "browser.cache.disk.smart_size.first_run": false,
-                  "browser.sessionstore.resume_from_crash": false,
-                  "browser.startup.page": 0,
-              };
-
-        mkdirp.sync(profileDir);
-
-        options.options = options.options || [];
-        if (!options.profile) {
-            options.tempDir = profileDir;
-        }
-
-        if (options.proxy) {
-            var match = /^(?:http:\/\/)?([^:/]+)(?::(\d+))?/.exec(
-                options.proxy
-            );
-            var host = JSON.stringify(match[1]);
-            var port = match[2] || 80;
-
-            assign(prefs, {
-                "network.proxy.http": host,
-                "network.proxy.http_port": +port,
-                "network.proxy.type": 1,
-                "network.proxy.no_proxies_on":
-                    '"' + formatNoProxyStandard(options) + '"',
-            });
-        }
-
-        if (options.prefs) {
-            assign(prefs, options.prefs);
-        }
-
-        prefs = Object.keys(prefs)
-            .map(function (name) {
-                return 'user_pref("' + name + '", ' + prefs[name] + ");";
-            })
-            .join("\n");
-
-        options.options = options.options.concat([
-            "--no-remote",
-            "-profile",
-            profileDir,
-        ]);
-
-        fs.writeFile(file, prefs, function (err) {
-            if (err) {
-                callback(err);
-            } else {
-                callback(null, options.options, []);
-            }
-        });
-    } else {
+    if (options.profile === null) {
+        // profile: null disables profile setup, so we can skip all of this. Unfortunately
+        // it's not possible to configure other settings without controlling the profile,
+        // so we error if you try:
         if (options.proxy || options.prefs) {
             callback(
                 new Error(
-                    "Cannot set proxy and or prefs options when profile is set to null."
+                    "Cannot set Firefox proxy and/or prefs options when profile is set to null."
                 )
             );
         }
 
         callback(null, options.options, []);
+        return;
     }
+
+    var profileDir = options.profile || path.join(os.tmpdir(), "browser-launcher" + uid(10));
+    var file = path.join(profileDir, 'prefs.js');
+    var prefs = options.skipDefaults ? {} : {
+        'browser.shell.checkDefaultBrowser': false,
+        'browser.bookmarks.restore_default_bookmarks': false,
+        'dom.disable_open_during_load': false,
+        'dom.max_script_run_time': 0,
+        'browser.cache.disk.capacity': 0,
+        'browser.cache.disk.smart_size.enabled': false,
+        'browser.cache.disk.smart_size.first_run': false,
+        'browser.sessionstore.resume_from_crash': false,
+        'browser.startup.page': 0
+    };
+
+    mkdirp.sync(profileDir);
+
+    options.options = options.options || [];
+    if (!options.profile) {
+        options.tempDir = profileDir;
+    }
+
+    if (options.proxy) {
+        var match = /^(?:http:\/\/)?([^:/]+)(?::(\d+))?/.exec(options.proxy);
+        var host = JSON.stringify(match[1]);
+        var port = match[2] || 80;
+
+        assign(prefs, {
+            'network.proxy.http': host,
+            'network.proxy.http_port': +port,
+            'network.proxy.type': 1,
+            'network.proxy.no_proxies_on': '"' + formatNoProxyStandard(options) + '"'
+        });
+    }
+
+    if (options.prefs) {
+        assign(prefs, options.prefs);
+    }
+
+    prefs = Object.keys(prefs).map(function (name) {
+        return 'user_pref("' + name + '", ' + prefs[name] + ');';
+    }).join('\n');
+
+    options.options = options.options.concat([
+        '--no-remote',
+        '-profile', profileDir
+    ]);
+
+    fs.writeFile(file, prefs, function (err) {
+        if (err) {
+            callback(err);
+        } else {
+            callback(null, options.options, []);
+        }
+    });
 };
 
 /**

--- a/lib/run.js
+++ b/lib/run.js
@@ -116,60 +116,82 @@ function formatNoProxyChrome(options) {
  * @param  {Function} callback Callback function
  */
 setups.firefox = function (browser, options, callback) {
-    var profileDir = options.profile || path.join(os.tmpdir(), 'browser-launcher' + uid(10));
-    var file = path.join(profileDir, 'prefs.js');
-    var prefs = options.skipDefaults ? {} : {
-        'browser.shell.checkDefaultBrowser': false,
-        'browser.bookmarks.restore_default_bookmarks': false,
-        'dom.disable_open_during_load': false,
-        'dom.max_script_run_time': 0,
-        'browser.cache.disk.capacity': 0,
-        'browser.cache.disk.smart_size.enabled': false,
-        'browser.cache.disk.smart_size.first_run': false,
-        'browser.sessionstore.resume_from_crash': false,
-        'browser.startup.page': 0
-    };
+    if (options.profile !== null) {
+        var profileDir =
+            options.profile ||
+            path.join(os.tmpdir(), "browser-launcher" + uid(10));
+        var file = path.join(profileDir, "prefs.js");
+        var prefs = options.skipDefaults
+            ? {}
+            : {
+                  "browser.shell.checkDefaultBrowser": false,
+                  "browser.bookmarks.restore_default_bookmarks": false,
+                  "dom.disable_open_during_load": false,
+                  "dom.max_script_run_time": 0,
+                  "browser.cache.disk.capacity": 0,
+                  "browser.cache.disk.smart_size.enabled": false,
+                  "browser.cache.disk.smart_size.first_run": false,
+                  "browser.sessionstore.resume_from_crash": false,
+                  "browser.startup.page": 0,
+              };
 
-    mkdirp.sync(profileDir);
+        mkdirp.sync(profileDir);
 
-    options.options = options.options || [];
-    if (!options.profile) {
-        options.tempDir = profileDir;
-    }
-
-    if (options.proxy) {
-        var match = /^(?:http:\/\/)?([^:/]+)(?::(\d+))?/.exec(options.proxy);
-        var host = JSON.stringify(match[1]);
-        var port = match[2] || 80;
-
-        assign(prefs, {
-            'network.proxy.http': host,
-            'network.proxy.http_port': +port,
-            'network.proxy.type': 1,
-            'network.proxy.no_proxies_on': '"' + formatNoProxyStandard(options) + '"'
-        });
-    }
-
-    if (options.prefs) {
-        assign(prefs, options.prefs);
-    }
-
-    prefs = Object.keys(prefs).map(function (name) {
-        return 'user_pref("' + name + '", ' + prefs[name] + ');';
-    }).join('\n');
-
-    options.options = options.options.concat([
-        '--no-remote',
-        '-profile', profileDir
-    ]);
-
-    fs.writeFile(file, prefs, function (err) {
-        if (err) {
-            callback(err);
-        } else {
-            callback(null, options.options, []);
+        options.options = options.options || [];
+        if (!options.profile) {
+            options.tempDir = profileDir;
         }
-    });
+
+        if (options.proxy) {
+            var match = /^(?:http:\/\/)?([^:/]+)(?::(\d+))?/.exec(
+                options.proxy
+            );
+            var host = JSON.stringify(match[1]);
+            var port = match[2] || 80;
+
+            assign(prefs, {
+                "network.proxy.http": host,
+                "network.proxy.http_port": +port,
+                "network.proxy.type": 1,
+                "network.proxy.no_proxies_on":
+                    '"' + formatNoProxyStandard(options) + '"',
+            });
+        }
+
+        if (options.prefs) {
+            assign(prefs, options.prefs);
+        }
+
+        prefs = Object.keys(prefs)
+            .map(function (name) {
+                return 'user_pref("' + name + '", ' + prefs[name] + ");";
+            })
+            .join("\n");
+
+        options.options = options.options.concat([
+            "--no-remote",
+            "-profile",
+            profileDir,
+        ]);
+
+        fs.writeFile(file, prefs, function (err) {
+            if (err) {
+                callback(err);
+            } else {
+                callback(null, options.options, []);
+            }
+        });
+    } else {
+        if (options.proxy || options.prefs) {
+            callback(
+                new Error(
+                    "Cannot set proxy and or prefs options when profile is set to null."
+                )
+            );
+        }
+
+        callback(null, options.options, []);
+    }
 };
 
 /**


### PR DESCRIPTION
Now you can launch Firefox with the default system profile by setting the profile option to null.

Note: don't set proxy nor prefs if you have set the profile to null.